### PR TITLE
Todo list not updated correctly on first login.

### DIFF
--- a/app/elements/todo-auth/todo-auth.html
+++ b/app/elements/todo-auth/todo-auth.html
@@ -64,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </firebase-auth>
 
     <paper-dialog modal
-                  opened="{{!user}}"
+                  opened="[[!user]]"
                   entry-animation="scale-up-animation"
                   exit-animation="fade-out-animation">
       <h2>Oh hai! Please sign in</h2>

--- a/app/test/index.html
+++ b/app/test/index.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body>
 
     <script>
-      WCT.loadSuites(['todo-list-basic.html']);
+      WCT.loadSuites(['todo-list-basic.html', 'todo-auth-basic.html']);
     </script>
 
 

--- a/app/test/todo-auth-basic.html
+++ b/app/test/todo-auth-basic.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>leave-type-menu-spec</title>
+
+  <script src="../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <link rel="import" href="../bower_components/polymer/polymer.html">
+  <script src="../bower_components/web-component-tester/browser.js"></script>
+  <script src="../bower_components/test-fixture/test-fixture-mocha.js"></script>
+  <link rel="import" href="../bower_components/test-fixture/test-fixture.html">
+
+  <!-- Step 1: import the element to test -->
+  <link rel="import" href="../elements/todo-auth/todo-auth.html">
+
+</head>
+<body>
+
+<test-fixture id="basic">
+  <template>
+    <todo-auth></todo-auth>
+  </template>
+</test-fixture>
+
+<script>
+
+  suite('<todo-auth>', function() {
+    var element, user;
+
+    setup(function() {
+      element = fixture('basic');
+      element.$.authenticate.detached = sinon.mock();
+      element.user= {provider: "Fake user object"};
+    });
+
+    test("paper-dialog should not corrupt user property", function() {
+      var paperDialog;
+      paperDialog = element.querySelector('paper-dialog');
+      paperDialog.open();
+      assert.deepEqual(element.user, {provider: "Fake user object"});
+    });
+  });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Hi,

This PR fixes the issue where todo list is not updated correctly on first login because user property is overwritten by paper-dialog. I've included a unit test that reproduces the error but I'm not sure if that's the correct way to mock firebase-auth. Feedback on how to write a better unit test would be greatly appreciated. 
